### PR TITLE
1.wx:for中wx:key不需要花括号 2. 使用wx:for替换wx:for-items

### DIFF
--- a/dist/example/grid/grid.wxml
+++ b/dist/example/grid/grid.wxml
@@ -5,7 +5,7 @@
     </view>
     <view class="page__bd">
         <view class="weui-grids">
-            <block wx:for-items="{{grids}}" wx:key="*this">
+            <block wx:for="{{grids}}" wx:key="*this">
                 <navigator url="" class="weui-grid" hover-class="weui-grid_active">
                     <image class="weui-grid__icon" src="../images/icon_tabbar.png" />
                     <view class="weui-grid__label">Grid</view>

--- a/dist/example/grid/grid.wxml
+++ b/dist/example/grid/grid.wxml
@@ -5,7 +5,7 @@
     </view>
     <view class="page__bd">
         <view class="weui-grids">
-            <block wx:for-items="{{grids}}" wx:key="{{index}}">
+            <block wx:for-items="{{grids}}" wx:key="*this">
                 <navigator url="" class="weui-grid" hover-class="weui-grid_active">
                     <image class="weui-grid__icon" src="../images/icon_tabbar.png" />
                     <view class="weui-grid__label">Grid</view>

--- a/dist/example/index.wxml
+++ b/dist/example/index.wxml
@@ -5,7 +5,7 @@
     </view>
     <view class="page__bd page__bd_spacing">
         <view class="kind-list">
-            <block wx:for-items="{{list}}" wx:key="id">
+            <block wx:for="{{list}}" wx:key="id">
                 <view class="kind-list__item">
                     <view id="{{item.id}}" class="weui-flex kind-list__item-hd {{item.open ? 'kind-list__item-hd_show' : ''}}" bindtap="kindToggle">
                         <view class="weui-flex__item">{{item.name}}</view>
@@ -13,7 +13,7 @@
                     </view>
                     <view class="kind-list__item-bd {{item.open ? 'kind-list__item-bd_show' : ''}}">
                         <view class="weui-cells {{item.open ? 'weui-cells_show' : ''}}">
-                            <block wx:for-items="{{item.pages}}" wx:for-item="page" wx:key="*this">
+                            <block wx:for="{{item.pages}}" wx:for-item="page" wx:key="*this">
                                 <navigator url="{{page}}/{{page}}" class="weui-cell weui-cell_access">
                                     <view class="weui-cell__bd">{{page}}</view>
                                     <view class="weui-cell__ft weui-cell__ft_in-access"></view>

--- a/dist/example/index.wxml
+++ b/dist/example/index.wxml
@@ -5,7 +5,7 @@
     </view>
     <view class="page__bd page__bd_spacing">
         <view class="kind-list">
-            <block wx:for-items="{{list}}" wx:key="{{item.id}}">
+            <block wx:for-items="{{list}}" wx:key="id">
                 <view class="kind-list__item">
                     <view id="{{item.id}}" class="weui-flex kind-list__item-hd {{item.open ? 'kind-list__item-hd_show' : ''}}" bindtap="kindToggle">
                         <view class="weui-flex__item">{{item.name}}</view>
@@ -13,7 +13,7 @@
                     </view>
                     <view class="kind-list__item-bd {{item.open ? 'kind-list__item-bd_show' : ''}}">
                         <view class="weui-cells {{item.open ? 'weui-cells_show' : ''}}">
-                            <block wx:for-items="{{item.pages}}" wx:for-item="page" wx:key="*item">
+                            <block wx:for-items="{{item.pages}}" wx:for-item="page" wx:key="*this">
                                 <navigator url="{{page}}/{{page}}" class="weui-cell weui-cell_access">
                                     <view class="weui-cell__bd">{{page}}</view>
                                     <view class="weui-cell__ft weui-cell__ft_in-access"></view>

--- a/dist/example/input/input.wxml
+++ b/dist/example/input/input.wxml
@@ -9,7 +9,7 @@
         <view class="weui-cells__title">单选列表项</view>
         <view class="weui-cells weui-cells_after-title">
             <radio-group bindchange="radioChange">
-                <label class="weui-cell weui-check__label" wx:for="{{radioItems}}" wx:key="{{item.value}}">
+                <label class="weui-cell weui-check__label" wx:for="{{radioItems}}" wx:key="value">
                     <radio class="weui-check" value="{{item.value}}" checked="{{item.checked}}"/>
 
                     <view class="weui-cell__bd">{{item.name}}</view>
@@ -26,7 +26,7 @@
         <view class="weui-cells__title">复选列表项</view>
         <view class="weui-cells weui-cells_after-title">
             <checkbox-group bindchange="checkboxChange">
-                <label class="weui-cell weui-check__label" wx:for="{{checkboxItems}}" wx:key="{{item.value}}">
+                <label class="weui-cell weui-check__label" wx:for="{{checkboxItems}}" wx:key="value">
                     <checkbox class="weui-check" value="{{item.value}}" checked="{{item.checked}}"/>
 
                     <view class="weui-cell__hd weui-check__hd_in-checkbox">

--- a/dist/example/navbar/navbar.wxml
+++ b/dist/example/navbar/navbar.wxml
@@ -2,7 +2,7 @@
     <view class="page__bd">
         <view class="weui-tab">
             <view class="weui-navbar">
-                <block wx:for-items="{{tabs}}" wx:key="{{index}}">
+                <block wx:for-items="{{tabs}}" wx:key="*this">
                     <view id="{{index}}" class="weui-navbar__item {{activeIndex == index ? 'weui-bar__item_on' : ''}}" bindtap="tabClick">
                         <view class="weui-navbar__title">{{item}}</view>
                     </view>

--- a/dist/example/navbar/navbar.wxml
+++ b/dist/example/navbar/navbar.wxml
@@ -2,7 +2,7 @@
     <view class="page__bd">
         <view class="weui-tab">
             <view class="weui-navbar">
-                <block wx:for-items="{{tabs}}" wx:key="*this">
+                <block wx:for="{{tabs}}" wx:key="*this">
                     <view id="{{index}}" class="weui-navbar__item {{activeIndex == index ? 'weui-bar__item_on' : ''}}" bindtap="tabClick">
                         <view class="weui-navbar__title">{{item}}</view>
                     </view>

--- a/dist/example/uploader/uploader.wxml
+++ b/dist/example/uploader/uploader.wxml
@@ -14,7 +14,7 @@
                         </view>
                         <view class="weui-uploader__bd">
                             <view class="weui-uploader__files" id="uploaderFiles">
-                                <block wx:for-items="{{files}}" wx:key="{{index}}">
+                                <block wx:for-items="{{files}}" wx:key="*this">
                                     <view class="weui-uploader__file" bindtap="previewImage" id="{{item}}">
                                         <image class="weui-uploader__img" src="{{item}}" mode="aspectFill" />
                                     </view>

--- a/dist/example/uploader/uploader.wxml
+++ b/dist/example/uploader/uploader.wxml
@@ -14,7 +14,7 @@
                         </view>
                         <view class="weui-uploader__bd">
                             <view class="weui-uploader__files" id="uploaderFiles">
-                                <block wx:for-items="{{files}}" wx:key="*this">
+                                <block wx:for="{{files}}" wx:key="*this">
                                     <view class="weui-uploader__file" bindtap="previewImage" id="{{item}}">
                                         <image class="weui-uploader__img" src="{{item}}" mode="aspectFill" />
                                     </view>

--- a/src/example/grid/grid.wxml
+++ b/src/example/grid/grid.wxml
@@ -5,7 +5,7 @@
     </view>
     <view class="page__bd">
         <view class="weui-grids">
-            <block wx:for-items="{{grids}}" wx:key="*this">
+            <block wx:for="{{grids}}" wx:key="*this">
                 <navigator url="" class="weui-grid" hover-class="weui-grid_active">
                     <image class="weui-grid__icon" src="../images/icon_tabbar.png" />
                     <view class="weui-grid__label">Grid</view>

--- a/src/example/grid/grid.wxml
+++ b/src/example/grid/grid.wxml
@@ -5,7 +5,7 @@
     </view>
     <view class="page__bd">
         <view class="weui-grids">
-            <block wx:for-items="{{grids}}" wx:key="{{index}}">
+            <block wx:for-items="{{grids}}" wx:key="*this">
                 <navigator url="" class="weui-grid" hover-class="weui-grid_active">
                     <image class="weui-grid__icon" src="../images/icon_tabbar.png" />
                     <view class="weui-grid__label">Grid</view>

--- a/src/example/index.wxml
+++ b/src/example/index.wxml
@@ -5,7 +5,7 @@
     </view>
     <view class="page__bd page__bd_spacing">
         <view class="kind-list">
-            <block wx:for-items="{{list}}" wx:key="id">
+            <block wx:for="{{list}}" wx:key="id">
                 <view class="kind-list__item">
                     <view id="{{item.id}}" class="weui-flex kind-list__item-hd {{item.open ? 'kind-list__item-hd_show' : ''}}" bindtap="kindToggle">
                         <view class="weui-flex__item">{{item.name}}</view>
@@ -13,7 +13,7 @@
                     </view>
                     <view class="kind-list__item-bd {{item.open ? 'kind-list__item-bd_show' : ''}}">
                         <view class="weui-cells {{item.open ? 'weui-cells_show' : ''}}">
-                            <block wx:for-items="{{item.pages}}" wx:for-item="page" wx:key="*this">
+                            <block wx:for="{{item.pages}}" wx:for-item="page" wx:key="*this">
                                 <navigator url="{{page}}/{{page}}" class="weui-cell weui-cell_access">
                                     <view class="weui-cell__bd">{{page}}</view>
                                     <view class="weui-cell__ft weui-cell__ft_in-access"></view>

--- a/src/example/index.wxml
+++ b/src/example/index.wxml
@@ -5,7 +5,7 @@
     </view>
     <view class="page__bd page__bd_spacing">
         <view class="kind-list">
-            <block wx:for-items="{{list}}" wx:key="{{item.id}}">
+            <block wx:for-items="{{list}}" wx:key="id">
                 <view class="kind-list__item">
                     <view id="{{item.id}}" class="weui-flex kind-list__item-hd {{item.open ? 'kind-list__item-hd_show' : ''}}" bindtap="kindToggle">
                         <view class="weui-flex__item">{{item.name}}</view>
@@ -13,7 +13,7 @@
                     </view>
                     <view class="kind-list__item-bd {{item.open ? 'kind-list__item-bd_show' : ''}}">
                         <view class="weui-cells {{item.open ? 'weui-cells_show' : ''}}">
-                            <block wx:for-items="{{item.pages}}" wx:for-item="page" wx:key="*item">
+                            <block wx:for-items="{{item.pages}}" wx:for-item="page" wx:key="*this">
                                 <navigator url="{{page}}/{{page}}" class="weui-cell weui-cell_access">
                                     <view class="weui-cell__bd">{{page}}</view>
                                     <view class="weui-cell__ft weui-cell__ft_in-access"></view>

--- a/src/example/input/input.wxml
+++ b/src/example/input/input.wxml
@@ -9,7 +9,7 @@
         <view class="weui-cells__title">单选列表项</view>
         <view class="weui-cells weui-cells_after-title">
             <radio-group bindchange="radioChange">
-                <label class="weui-cell weui-check__label" wx:for="{{radioItems}}" wx:key="{{item.value}}">
+                <label class="weui-cell weui-check__label" wx:for="{{radioItems}}" wx:key="value">
                     <radio class="weui-check" value="{{item.value}}" checked="{{item.checked}}"/>
 
                     <view class="weui-cell__bd">{{item.name}}</view>
@@ -26,7 +26,7 @@
         <view class="weui-cells__title">复选列表项</view>
         <view class="weui-cells weui-cells_after-title">
             <checkbox-group bindchange="checkboxChange">
-                <label class="weui-cell weui-check__label" wx:for="{{checkboxItems}}" wx:key="{{item.value}}">
+                <label class="weui-cell weui-check__label" wx:for="{{checkboxItems}}" wx:key="value">
                     <checkbox class="weui-check" value="{{item.value}}" checked="{{item.checked}}"/>
 
                     <view class="weui-cell__hd weui-check__hd_in-checkbox">

--- a/src/example/navbar/navbar.wxml
+++ b/src/example/navbar/navbar.wxml
@@ -2,7 +2,7 @@
     <view class="page__bd">
         <view class="weui-tab">
             <view class="weui-navbar">
-                <block wx:for-items="{{tabs}}" wx:key="{{index}}">
+                <block wx:for-items="{{tabs}}" wx:key="*this">
                     <view id="{{index}}" class="weui-navbar__item {{activeIndex == index ? 'weui-bar__item_on' : ''}}" bindtap="tabClick">
                         <view class="weui-navbar__title">{{item}}</view>
                     </view>

--- a/src/example/navbar/navbar.wxml
+++ b/src/example/navbar/navbar.wxml
@@ -2,7 +2,7 @@
     <view class="page__bd">
         <view class="weui-tab">
             <view class="weui-navbar">
-                <block wx:for-items="{{tabs}}" wx:key="*this">
+                <block wx:for="{{tabs}}" wx:key="*this">
                     <view id="{{index}}" class="weui-navbar__item {{activeIndex == index ? 'weui-bar__item_on' : ''}}" bindtap="tabClick">
                         <view class="weui-navbar__title">{{item}}</view>
                     </view>

--- a/src/example/uploader/uploader.wxml
+++ b/src/example/uploader/uploader.wxml
@@ -14,7 +14,7 @@
                         </view>
                         <view class="weui-uploader__bd">
                             <view class="weui-uploader__files" id="uploaderFiles">
-                                <block wx:for-items="{{files}}" wx:key="{{index}}">
+                                <block wx:for-items="{{files}}" wx:key="*this">
                                     <view class="weui-uploader__file" bindtap="previewImage" id="{{item}}">
                                         <image class="weui-uploader__img" src="{{item}}" mode="aspectFill" />
                                     </view>

--- a/src/example/uploader/uploader.wxml
+++ b/src/example/uploader/uploader.wxml
@@ -14,7 +14,7 @@
                         </view>
                         <view class="weui-uploader__bd">
                             <view class="weui-uploader__files" id="uploaderFiles">
-                                <block wx:for-items="{{files}}" wx:key="*this">
+                                <block wx:for="{{files}}" wx:key="*this">
                                     <view class="weui-uploader__file" bindtap="previewImage" id="{{item}}">
                                         <image class="weui-uploader__img" src="{{item}}" mode="aspectFill" />
                                     </view>


### PR DESCRIPTION
1. wx:for中wx:key不需要花括号 

2. 如果wx:key使用item使用*this

3. 在文档中没有wx:for-items了，使用wx:for替换。[wx:for文档](https://mp.weixin.qq.com/debug/wxadoc/dev/framework/view/wxml/list.html)